### PR TITLE
Implement support for user flag to run within root context

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ To set other browsers as the default, use the following identifiers:
 - Firefox: `org.mozilla.firefox`
 - MS Edge: `com.microsoft.edgemac`
 
+To set the default browser for another user, run within a root context and specify `--user`. The user account must exist.
+
+```shell
+/opt/macadmins/bin/default-browser --identifier com.google.chrome --user tim.apple
+```
+
 ## Known issues
 
 ### System Settings may not work correctly

--- a/main.go
+++ b/main.go
@@ -25,12 +25,11 @@ func main() {
 		},
 	}
 
-	rootCmd.Flags().StringVar(&identifier, "identifier", "", "An identifier for the application")
+	rootCmd.Flags().StringVar(&identifier, "identifier", "com.google.chrome", "An identifier for the application")
 	rootCmd.Flags().BoolVar(&noRescanLaunchServices, "no-rescan-launchservices", false, "Do not rescan launch services.")
 	rootCmd.Flags().BoolVar(&noRescanLaunchServices, "no-rebuild-launchservices", false, "Legacy: same as --no-rescan-launchservices")
 	rootCmd.Flags().StringVar(&targetUser, "user", "", "Username to operate on (only allowed when run as root)")
 
-	rootCmd.MarkFlagRequired("identifier")
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("default-browser version {{.Version}}\n")
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
 
 	"github.com/macadmins/default-browser/pkg/client"
 	"github.com/macadmins/default-browser/pkg/launchservices"
@@ -14,39 +17,53 @@ var version string
 func main() {
 	var identifier string
 	var noRescanLaunchServices bool
+	var targetUser string
 
 	var rootCmd = &cobra.Command{
 		Use:   "default-browser",
 		Short: "A cli tool to set the default browser on macOS",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return setDefault(identifier, noRescanLaunchServices)
+			return setDefault(identifier, noRescanLaunchServices, targetUser)
 		},
 	}
 
-	rootCmd.Flags().StringVar(&identifier, "identifier", "com.google.chrome", "An identifier for the application")
-	rootCmd.Flags().BoolVar(&noRescanLaunchServices, "no-rescan-launchservices", false, "Do not rescan launch services. Only use if you are experiencing issues with System Settings not displaying correctly after a reboot.")
+	rootCmd.Flags().StringVar(&identifier, "identifier", "", "An identifier for the application")
+	rootCmd.Flags().BoolVar(&noRescanLaunchServices, "no-rescan-launchservices", false, "Do not rescan launch services.")
 	rootCmd.Flags().BoolVar(&noRescanLaunchServices, "no-rebuild-launchservices", false, "Legacy: same as --no-rescan-launchservices")
+	rootCmd.Flags().StringVar(&targetUser, "user", "", "Username to operate on (only allowed when run as root)")
 
+	rootCmd.MarkFlagRequired("identifier")
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("default-browser version {{.Version}}\n")
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }
 
-func setDefault(identifier string, noRescanLaunchServices bool) error {
-	if identifier == "" {
-		return fmt.Errorf("identifier cannot be empty")
-	}
+func setDefault(identifier string, noRescanLaunchServices bool, targetUser string) error {
+	var opts []client.Option
 
-	// Todo: actually run as the logged in user if run as root. For now just bail
 	if os.Geteuid() == 0 {
-		return fmt.Errorf("this tool must be run as the logged in user")
+		if targetUser == "" {
+			return fmt.Errorf("--user must be specified when running as root")
+		}
+	
+		// Look up the specified user and construct the correct plist path
+		u, err := user.Lookup(targetUser)
+		if err != nil {
+			return fmt.Errorf("unknown user %s", targetUser)
+		}
+
+		plistPath := filepath.Join(u.HomeDir, "Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist")
+		opts = append(opts, client.WithCurrentUser(targetUser), client.WithPlistLocation(plistPath))
+	} else {
+		if targetUser != "" {
+			return fmt.Errorf("--user can only be used when running as root")
+		}
 	}
 
-	c, err := client.NewClient()
+	c, err := client.NewClient(opts...)
 	if err != nil {
 		return err
 	}
@@ -55,5 +72,27 @@ func setDefault(identifier string, noRescanLaunchServices bool) error {
 	if err != nil {
 		return err
 	}
+
+	// Fix ownership if specifying --user
+	if os.Geteuid() == 0 {
+		uid, err := parseUID(u)
+		if err != nil {
+			return err
+		}
+
+		err = os.Chown(c.PlistLocation, uid, 20) // gid 20 = staff
+		if err != nil {
+			return fmt.Errorf("failed to chown plist: %v", err)
+		}
+	}
+
 	return nil
+}
+
+func parseUID(u *user.User) (int, error) {
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, fmt.Errorf("invalid UID for user %s: %v", u.Username, err)
+	}
+	return uid, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"os/user"
+	"path/filepath"
 
 	osq "github.com/macadmins/osquery-extension/pkg/utils"
 )
@@ -42,7 +43,11 @@ func NewClient(opts ...Option) (Client, error) {
 	}
 
 	if c.PlistLocation == "" {
-		c.PlistLocation = "/Users/" + c.CurrentUser + "/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+		userInfo, err := LookupUserInfo(c.CurrentUser)
+		if err != nil {
+			return c, err
+		}
+		c.PlistLocation = filepath.Join(userInfo.HomeDir, "Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist")
 	}
 
 	return c, nil

--- a/pkg/client/userinfo.go
+++ b/pkg/client/userinfo.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+)
+
+type UserInfo struct {
+	Username string
+	UID      int
+	HomeDir  string
+}
+
+func LookupUserInfo(username string) (*UserInfo, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("unknown user %s", username)
+	}
+
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("invalid UID for user %s: %v", u.Username, err)
+	}
+
+	return &UserInfo{
+		Username: u.Username,
+		UID:      uid,
+		HomeDir:  u.HomeDir,
+	}, nil
+}
+
+func FixPlistOwnership(username, plistPath string) error {
+	userInfo, err := LookupUserInfo(username)
+	if err != nil {
+		return err
+	}
+
+	// Use default group staff (GID 20)
+	const staffGID = 20
+
+	if err := os.Chown(plistPath, userInfo.UID, staffGID); err != nil {
+		return fmt.Errorf("failed to chown plist: %v", err)
+	}
+
+	if err := os.Chmod(plistPath, 0644); err != nil {
+		return fmt.Errorf("failed to chmod plist: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/client/userinfo_test.go
+++ b/pkg/client/userinfo_test.go
@@ -1,0 +1,54 @@
+package client_test
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/macadmins/default-browser/pkg/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupUserInfo(t *testing.T) {
+	currentUser, err := user.Current()
+	assert.NoError(t, err, "user.Current should not return an error")
+
+	info, err := client.LookupUserInfo(currentUser.Username)
+	assert.NoError(t, err, "LookupUserInfo should not return an error")
+	assert.Equal(t, currentUser.Username, info.Username, "Username should match")
+	assert.Equal(t, currentUser.HomeDir, info.HomeDir, "HomeDir should match")
+	assert.Greater(t, info.UID, 0, "UID should be greater than 0")
+}
+
+func TestLookupUserInfo_InvalidUser(t *testing.T) {
+	_, err := client.LookupUserInfo("not-a-real-user")
+	assert.Error(t, err, "LookupUserInfo should return an error for a non-existent user")
+}
+
+func TestFixPlistOwnership(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("TestFixPlistOwnership requires root privileges")
+	}
+
+	currentUser, err := user.Current()
+	assert.NoError(t, err, "user.Current should not return an error")
+
+	tmpfile, err := os.CreateTemp("", "test.plist")
+	assert.NoError(t, err, "CreateTemp should not return an error")
+	defer os.Remove(tmpfile.Name())
+
+	err = client.FixPlistOwnership(currentUser.Username, tmpfile.Name())
+	assert.NoError(t, err, "FixPlistOwnership should not return an error")
+
+	info, err := os.Stat(tmpfile.Name())
+	assert.NoError(t, err, "Stat should not return an error")
+
+	stat := info.Sys().(*os.FileStat)
+	assert.Equal(t, uint32(0644), info.Mode().Perm(), "File mode should be 0644")
+
+	// Convert UID to string for comparison with currentUser.Uid
+	fileUID := strconv.Itoa(int(stat.Uid))
+	assert.Equal(t, currentUser.Uid, fileUID, "File owner UID should match current user")
+}


### PR DESCRIPTION
I'd like to be able to set the default browser within a root context like when automating deployment of a new Mac. Most of my onboarding tools run as root already, and though I could run as a user, `default-browser` doesn't currently have support for anything other than Go's built in `CurrentUser`. This PR adds `--user` as an optional flag when running as root/sudo. When `--user` is provided the launch services plist for that user is modified.

- Adds user flag. Must be run as root.
- More properly constructs the path to `com.apple.launchservices.secure.plist` by getting the user's home dir, and not assuming `/Users/$username`.