### PR TITLE
Use actual home directory for LaunchServices plist

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"os"
 	"os/user"
 
 	osq "github.com/macadmins/osquery-extension/pkg/utils"
@@ -16,6 +17,7 @@ type Client struct {
 
 type Option func(*Client)
 type currentUserLookup func() (*user.User, error)
+type homeDirLookup func() (string, error)
 
 func WithCurrentUser(currentUser string) Option {
 	return func(c *Client) {
@@ -30,10 +32,10 @@ func WithPlistLocation(plistLocation string) Option {
 }
 
 func NewClient(opts ...Option) (Client, error) {
-	return newClient(user.Current, opts...)
+	return newClient(user.Current, os.UserHomeDir, opts...)
 }
 
-func newClient(lookupCurrentUser currentUserLookup, opts ...Option) (Client, error) {
+func newClient(lookupCurrentUser currentUserLookup, lookupHomeDir homeDirLookup, opts ...Option) (Client, error) {
 	c := Client{}
 	c.Runner = osq.NewRunner().Runner
 	for _, opt := range opts {
@@ -49,12 +51,16 @@ func newClient(lookupCurrentUser currentUserLookup, opts ...Option) (Client, err
 	}
 
 	if c.PlistLocation == "" {
-		c.PlistLocation = defaultLaunchServicesPlistLocation(c.CurrentUser)
+		homeDir, err := lookupHomeDir()
+		if err != nil {
+			return c, err
+		}
+		c.PlistLocation = defaultLaunchServicesPlistLocation(homeDir)
 	}
 
 	return c, nil
 }
 
-func defaultLaunchServicesPlistLocation(currentUser string) string {
-	return "/Users/" + currentUser + "/" + launchServicesPlistPath
+func defaultLaunchServicesPlistLocation(homeDir string) string {
+	return homeDir + "/" + launchServicesPlistPath
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"os"
 	"os/user"
 
 	osq "github.com/macadmins/osquery-extension/pkg/utils"
@@ -12,16 +11,22 @@ const launchServicesPlistPath = "Library/Preferences/com.apple.LaunchServices/co
 type Client struct {
 	Runner        osq.CmdRunner
 	CurrentUser   string
+	HomeDir       string
 	PlistLocation string
 }
 
 type Option func(*Client)
 type currentUserLookup func() (*user.User, error)
-type homeDirLookup func() (string, error)
 
 func WithCurrentUser(currentUser string) Option {
 	return func(c *Client) {
 		c.CurrentUser = currentUser
+	}
+}
+
+func WithHomeDir(homeDir string) Option {
+	return func(c *Client) {
+		c.HomeDir = homeDir
 	}
 }
 
@@ -32,30 +37,31 @@ func WithPlistLocation(plistLocation string) Option {
 }
 
 func NewClient(opts ...Option) (Client, error) {
-	return newClient(user.Current, os.UserHomeDir, opts...)
+	return newClient(user.Current, opts...)
 }
 
-func newClient(lookupCurrentUser currentUserLookup, lookupHomeDir homeDirLookup, opts ...Option) (Client, error) {
+func newClient(lookupCurrentUser currentUserLookup, opts ...Option) (Client, error) {
 	c := Client{}
 	c.Runner = osq.NewRunner().Runner
 	for _, opt := range opts {
 		opt(&c)
 	}
 
-	if c.CurrentUser == "" {
+	if c.CurrentUser == "" || c.HomeDir == "" {
 		currentUser, err := lookupCurrentUser()
 		if err != nil {
 			return c, err
 		}
-		c.CurrentUser = currentUser.Username
+		if c.CurrentUser == "" {
+			c.CurrentUser = currentUser.Username
+		}
+		if c.HomeDir == "" {
+			c.HomeDir = currentUser.HomeDir
+		}
 	}
 
 	if c.PlistLocation == "" {
-		homeDir, err := lookupHomeDir()
-		if err != nil {
-			return c, err
-		}
-		c.PlistLocation = defaultLaunchServicesPlistLocation(homeDir)
+		c.PlistLocation = defaultLaunchServicesPlistLocation(c.HomeDir)
 	}
 
 	return c, nil

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestNewClient(t *testing.T) {
 	client, err := NewClient()
+
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.NotNil(t, client.Runner, "Runner should not be nil")
 	assert.IsType(t, &osq.ExecCmdRunner{}, client.Runner, "Runner should be of type osq.Runner")
@@ -18,51 +19,104 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientWithCurrentUser(t *testing.T) {
 	expectedUser := "testuser"
-	client, err := NewClient(WithCurrentUser(expectedUser))
+	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return nil, errors.New("current user lookup should not be called")
+		},
+		func() (string, error) {
+			return expectedHomeDir, nil
+		},
+		WithCurrentUser(expectedUser),
+	)
+
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, "/Users/testuser/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the provided current user")
+	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
 
 func TestNewClientDefaultCurrentUser(t *testing.T) {
-	client, err := newClient(func() (*user.User, error) {
-		return &user.User{Username: "systemuser"}, nil
-	})
+	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: "systemuser"}, nil
+		},
+		func() (string, error) {
+			return expectedHomeDir, nil
+		},
+	)
+
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.Equal(t, "systemuser", client.CurrentUser, "CurrentUser should be set to the system's current user")
-	assert.Equal(t, "/Users/systemuser/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the system's current user")
+	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
 
 func TestNewClientWithPlistLocation(t *testing.T) {
 	expectedPlistLocation := "/tmp/test.plist"
+
 	client, err := NewClient(WithPlistLocation(expectedPlistLocation))
+
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
 }
 
 func TestNewClientWithCurrentUserSkipsCurrentUserLookup(t *testing.T) {
-	client, err := newClient(func() (*user.User, error) {
-		return nil, errors.New("current user lookup should not be called")
-	}, WithCurrentUser("testuser"))
+	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return nil, errors.New("current user lookup should not be called")
+		},
+		func() (string, error) {
+			return expectedHomeDir, nil
+		},
+		WithCurrentUser("testuser"),
+	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.Equal(t, "testuser", client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, "/Users/testuser/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the provided current user")
+	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
 
 func TestNewClientReturnsCurrentUserLookupError(t *testing.T) {
 	expectedErr := errors.New("current user lookup failed")
 
-	client, err := newClient(func() (*user.User, error) {
-		return nil, expectedErr
-	})
+	client, err := newClient(
+		func() (*user.User, error) {
+			return nil, expectedErr
+		},
+		func() (string, error) {
+			return "/Volumes/test_volume/Users/testuser", nil
+		},
+	)
 
 	assert.ErrorIs(t, err, expectedErr, "NewClient should return the current user lookup error")
 	assert.Empty(t, client.CurrentUser, "CurrentUser should not be set when lookup fails")
 }
 
-func TestDefaultLaunchServicesPlistLocation(t *testing.T) {
-	location := defaultLaunchServicesPlistLocation("testuser")
+func TestNewClientReturnsHomeDirLookupError(t *testing.T) {
+	expectedErr := errors.New("home directory lookup failed")
 
-	assert.Equal(t, "/Users/testuser/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", location, "default LaunchServices plist location should match the legacy path")
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: "testuser"}, nil
+		},
+		func() (string, error) {
+			return "", expectedErr
+		},
+	)
+
+	assert.ErrorIs(t, err, expectedErr, "NewClient should return the home directory lookup error")
+	assert.Equal(t, "testuser", client.CurrentUser, "CurrentUser should be set before home directory lookup")
+	assert.Empty(t, client.PlistLocation, "PlistLocation should not be set when home directory lookup fails")
+}
+
+func TestDefaultLaunchServicesPlistLocation(t *testing.T) {
+	homeDir := "/Volumes/test_volume/Users/testuser"
+
+	location := defaultLaunchServicesPlistLocation(homeDir)
+
+	assert.Equal(t, homeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", location, "default LaunchServices plist location should use the provided home directory")
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -15,9 +15,75 @@ func TestNewClient(t *testing.T) {
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.NotNil(t, client.Runner, "Runner should not be nil")
 	assert.IsType(t, &osq.ExecCmdRunner{}, client.Runner, "Runner should be of type osq.Runner")
+	assert.NotEmpty(t, client.CurrentUser, "CurrentUser should not be empty")
+	assert.NotEmpty(t, client.HomeDir, "HomeDir should not be empty")
+	assert.Equal(t, defaultLaunchServicesPlistLocation(client.HomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
 
 func TestNewClientWithCurrentUser(t *testing.T) {
+	expectedUser := "testuser"
+	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: "systemuser", HomeDir: expectedHomeDir}, nil
+		},
+		WithCurrentUser(expectedUser),
+	)
+
+	assert.NoError(t, err, "NewClient should not return an error")
+	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
+	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set from the current user lookup")
+	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
+}
+
+func TestNewClientWithHomeDir(t *testing.T) {
+	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: "systemuser", HomeDir: "/Users/systemuser"}, nil
+		},
+		WithHomeDir(expectedHomeDir),
+	)
+
+	assert.NoError(t, err, "NewClient should not return an error")
+	assert.Equal(t, "systemuser", client.CurrentUser, "CurrentUser should be set from the current user lookup")
+	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
+	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the provided home directory")
+}
+
+func TestNewClientDefaultCurrentUser(t *testing.T) {
+	expectedUser := "systemuser"
+	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: expectedUser, HomeDir: expectedHomeDir}, nil
+		},
+	)
+
+	assert.NoError(t, err, "NewClient should not return an error")
+	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the system's current user")
+	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the system's current user's home directory")
+	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
+}
+
+func TestNewClientWithPlistLocation(t *testing.T) {
+	expectedPlistLocation := "/tmp/test.plist"
+
+	client, err := newClient(
+		func() (*user.User, error) {
+			return &user.User{Username: "systemuser", HomeDir: "/Volumes/test_volume/Users/systemuser"}, nil
+		},
+		WithPlistLocation(expectedPlistLocation),
+	)
+
+	assert.NoError(t, err, "NewClient should not return an error")
+	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
+}
+
+func TestNewClientWithCurrentUserAndHomeDirSkipsCurrentUserLookup(t *testing.T) {
 	expectedUser := "testuser"
 	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
 
@@ -25,59 +91,34 @@ func TestNewClientWithCurrentUser(t *testing.T) {
 		func() (*user.User, error) {
 			return nil, errors.New("current user lookup should not be called")
 		},
-		func() (string, error) {
-			return expectedHomeDir, nil
-		},
 		WithCurrentUser(expectedUser),
+		WithHomeDir(expectedHomeDir),
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
+	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
+	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the provided home directory")
 }
 
-func TestNewClientDefaultCurrentUser(t *testing.T) {
-	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
-
-	client, err := newClient(
-		func() (*user.User, error) {
-			return &user.User{Username: "systemuser"}, nil
-		},
-		func() (string, error) {
-			return expectedHomeDir, nil
-		},
-	)
-
-	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, "systemuser", client.CurrentUser, "CurrentUser should be set to the system's current user")
-	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
-}
-
-func TestNewClientWithPlistLocation(t *testing.T) {
-	expectedPlistLocation := "/tmp/test.plist"
-
-	client, err := NewClient(WithPlistLocation(expectedPlistLocation))
-
-	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
-}
-
-func TestNewClientWithCurrentUserSkipsCurrentUserLookup(t *testing.T) {
+func TestNewClientWithCurrentUserHomeDirAndPlistLocationSkipsCurrentUserLookup(t *testing.T) {
+	expectedUser := "testuser"
 	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
+	expectedPlistLocation := "/tmp/test.plist"
 
 	client, err := newClient(
 		func() (*user.User, error) {
 			return nil, errors.New("current user lookup should not be called")
 		},
-		func() (string, error) {
-			return expectedHomeDir, nil
-		},
-		WithCurrentUser("testuser"),
+		WithCurrentUser(expectedUser),
+		WithHomeDir(expectedHomeDir),
+		WithPlistLocation(expectedPlistLocation),
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, "testuser", client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, expectedHomeDir+"/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist", client.PlistLocation, "PlistLocation should use the current user's actual home directory")
+	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
+	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
+	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
 }
 
 func TestNewClientReturnsCurrentUserLookupError(t *testing.T) {
@@ -87,30 +128,12 @@ func TestNewClientReturnsCurrentUserLookupError(t *testing.T) {
 		func() (*user.User, error) {
 			return nil, expectedErr
 		},
-		func() (string, error) {
-			return "/Volumes/test_volume/Users/testuser", nil
-		},
 	)
 
 	assert.ErrorIs(t, err, expectedErr, "NewClient should return the current user lookup error")
 	assert.Empty(t, client.CurrentUser, "CurrentUser should not be set when lookup fails")
-}
-
-func TestNewClientReturnsHomeDirLookupError(t *testing.T) {
-	expectedErr := errors.New("home directory lookup failed")
-
-	client, err := newClient(
-		func() (*user.User, error) {
-			return &user.User{Username: "testuser"}, nil
-		},
-		func() (string, error) {
-			return "", expectedErr
-		},
-	)
-
-	assert.ErrorIs(t, err, expectedErr, "NewClient should return the home directory lookup error")
-	assert.Equal(t, "testuser", client.CurrentUser, "CurrentUser should be set before home directory lookup")
-	assert.Empty(t, client.PlistLocation, "PlistLocation should not be set when home directory lookup fails")
+	assert.Empty(t, client.HomeDir, "HomeDir should not be set when lookup fails")
+	assert.Empty(t, client.PlistLocation, "PlistLocation should not be set when lookup fails")
 }
 
 func TestDefaultLaunchServicesPlistLocation(t *testing.T) {


### PR DESCRIPTION
Fixes handling for macOS accounts whose home directories are not under `/Users/$USER`.

`default-browser` currently constructs the LaunchServices plist path using `/Users/<username>`. That fails for accounts whose `NFSHomeDirectory` points to another volume, for example:

```sh
$ echo "$HOME"
/Volumes/some_personal_volume/Users/oliver

$ dscl . -read /Users/oliver NFSHomeDirectory
NFSHomeDirectory: /Volumes/some_personal_volume/Users/oliver
```
In that case, running default-browser --identifier ... fails while trying to create /Users/<username>.

This change uses os.UserHomeDir() when constructing the default LaunchServices plist path, while preserving the existing WithPlistLocation override behavior.

