### PR TITLE
Fix lint CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
-      - uses: actions/checkout@v2
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6.5.2
+        with:
+          version: v1.64.8


### PR DESCRIPTION
Fixes the failing lint job seen on PR #24. The old workflow ran setup-go before checkout and did not pin the Go version, so Actions resolved Go 1.26 while golangci-lint v1.64.8 was built with Go 1.24, causing typecheck failures before lint could run cleanly. This updates the lint workflow to checkout first, use setup-go v6 with go.mod, and pins golangci-lint-action to the v6 line with golangci-lint v1.64.8 so the existing lint behavior is preserved. Verified locally with: GOCACHE=/tmp/default-browser-go-build GOMODCACHE=/tmp/default-browser-go-mod go test ./...; GOCACHE=/tmp/default-browser-go-build GOMODCACHE=/tmp/default-browser-go-mod go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run.