### PR TITLE
Prepare 1.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,16 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      VERSION: 1.0.${{ github.run_number }}
+      VERSION: 1.1.${{ github.run_number }}
     steps:
       - name: Checkout code
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Install Apple Xcode certificates
         uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
         with:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,19 +10,12 @@ const launchServicesPlistPath = "Library/Preferences/com.apple.LaunchServices/co
 
 type Client struct {
 	Runner        osq.CmdRunner
-	CurrentUser   string
 	HomeDir       string
 	PlistLocation string
 }
 
 type Option func(*Client)
 type currentUserLookup func() (*user.User, error)
-
-func WithCurrentUser(currentUser string) Option {
-	return func(c *Client) {
-		c.CurrentUser = currentUser
-	}
-}
 
 func WithHomeDir(homeDir string) Option {
 	return func(c *Client) {
@@ -47,17 +40,12 @@ func newClient(lookupCurrentUser currentUserLookup, opts ...Option) (Client, err
 		opt(&c)
 	}
 
-	if c.CurrentUser == "" || c.HomeDir == "" {
+	if c.HomeDir == "" && c.PlistLocation == "" {
 		currentUser, err := lookupCurrentUser()
 		if err != nil {
 			return c, err
 		}
-		if c.CurrentUser == "" {
-			c.CurrentUser = currentUser.Username
-		}
-		if c.HomeDir == "" {
-			c.HomeDir = currentUser.HomeDir
-		}
+		c.HomeDir = currentUser.HomeDir
 	}
 
 	if c.PlistLocation == "" {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -15,56 +15,36 @@ func TestNewClient(t *testing.T) {
 	assert.NoError(t, err, "NewClient should not return an error")
 	assert.NotNil(t, client.Runner, "Runner should not be nil")
 	assert.IsType(t, &osq.ExecCmdRunner{}, client.Runner, "Runner should be of type osq.Runner")
-	assert.NotEmpty(t, client.CurrentUser, "CurrentUser should not be empty")
 	assert.NotEmpty(t, client.HomeDir, "HomeDir should not be empty")
 	assert.Equal(t, defaultLaunchServicesPlistLocation(client.HomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
 
-func TestNewClientWithCurrentUser(t *testing.T) {
-	expectedUser := "testuser"
-	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
-
-	client, err := newClient(
-		func() (*user.User, error) {
-			return &user.User{Username: "systemuser", HomeDir: expectedHomeDir}, nil
-		},
-		WithCurrentUser(expectedUser),
-	)
-
-	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set from the current user lookup")
-	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
-}
-
 func TestNewClientWithHomeDir(t *testing.T) {
 	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
+	expectedPlistLocation := "/Volumes/test_volume/Users/testuser/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
 
 	client, err := newClient(
 		func() (*user.User, error) {
-			return &user.User{Username: "systemuser", HomeDir: "/Users/systemuser"}, nil
+			return nil, errors.New("current user lookup should not be called")
 		},
 		WithHomeDir(expectedHomeDir),
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, "systemuser", client.CurrentUser, "CurrentUser should be set from the current user lookup")
 	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
-	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the provided home directory")
+	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should use the provided home directory")
 }
 
-func TestNewClientDefaultCurrentUser(t *testing.T) {
-	expectedUser := "systemuser"
+func TestNewClientDefaultHomeDir(t *testing.T) {
 	expectedHomeDir := "/Volumes/test_volume/Users/systemuser"
 
 	client, err := newClient(
 		func() (*user.User, error) {
-			return &user.User{Username: expectedUser, HomeDir: expectedHomeDir}, nil
+			return &user.User{HomeDir: expectedHomeDir}, nil
 		},
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the system's current user")
 	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the system's current user's home directory")
 	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the current user's actual home directory")
 }
@@ -74,35 +54,17 @@ func TestNewClientWithPlistLocation(t *testing.T) {
 
 	client, err := newClient(
 		func() (*user.User, error) {
-			return &user.User{Username: "systemuser", HomeDir: "/Volumes/test_volume/Users/systemuser"}, nil
+			return nil, errors.New("current user lookup should not be called")
 		},
 		WithPlistLocation(expectedPlistLocation),
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
+	assert.Empty(t, client.HomeDir, "HomeDir should not be set when only PlistLocation is provided")
 	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
 }
 
-func TestNewClientWithCurrentUserAndHomeDirSkipsCurrentUserLookup(t *testing.T) {
-	expectedUser := "testuser"
-	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
-
-	client, err := newClient(
-		func() (*user.User, error) {
-			return nil, errors.New("current user lookup should not be called")
-		},
-		WithCurrentUser(expectedUser),
-		WithHomeDir(expectedHomeDir),
-	)
-
-	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
-	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
-	assert.Equal(t, defaultLaunchServicesPlistLocation(expectedHomeDir), client.PlistLocation, "PlistLocation should use the provided home directory")
-}
-
-func TestNewClientWithCurrentUserHomeDirAndPlistLocationSkipsCurrentUserLookup(t *testing.T) {
-	expectedUser := "testuser"
+func TestNewClientWithHomeDirAndPlistLocation(t *testing.T) {
 	expectedHomeDir := "/Volumes/test_volume/Users/testuser"
 	expectedPlistLocation := "/tmp/test.plist"
 
@@ -110,13 +72,11 @@ func TestNewClientWithCurrentUserHomeDirAndPlistLocationSkipsCurrentUserLookup(t
 		func() (*user.User, error) {
 			return nil, errors.New("current user lookup should not be called")
 		},
-		WithCurrentUser(expectedUser),
 		WithHomeDir(expectedHomeDir),
 		WithPlistLocation(expectedPlistLocation),
 	)
 
 	assert.NoError(t, err, "NewClient should not return an error")
-	assert.Equal(t, expectedUser, client.CurrentUser, "CurrentUser should be set to the provided value")
 	assert.Equal(t, expectedHomeDir, client.HomeDir, "HomeDir should be set to the provided value")
 	assert.Equal(t, expectedPlistLocation, client.PlistLocation, "PlistLocation should be set to the provided value")
 }
@@ -131,7 +91,6 @@ func TestNewClientReturnsCurrentUserLookupError(t *testing.T) {
 	)
 
 	assert.ErrorIs(t, err, expectedErr, "NewClient should return the current user lookup error")
-	assert.Empty(t, client.CurrentUser, "CurrentUser should not be set when lookup fails")
 	assert.Empty(t, client.HomeDir, "HomeDir should not be set when lookup fails")
 	assert.Empty(t, client.PlistLocation, "PlistLocation should not be set when lookup fails")
 }


### PR DESCRIPTION
## Summary
- remove the unused CurrentUser client field and the unused WithCurrentUser option
- skip current-user lookup when callers provide a HomeDir or PlistLocation, since the client only needs paths
- bump release versions to 1.1.x and make the release workflow use the Go version from go.mod

## Verification
- rtk env GOCACHE=/tmp/default-browser-go-build GOMODCACHE=/tmp/default-browser-go-mod go test ./...
- rtk env GOCACHE=/tmp/default-browser-go-build GOMODCACHE=/tmp/default-browser-go-mod go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
- rtk env GOCACHE=/tmp/default-browser-go-build GOMODCACHE=/tmp/default-browser-go-mod go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --disable=errcheck